### PR TITLE
Respecting custom asset prefix

### DIFF
--- a/vendor/assets/javascripts/ckeditor/basepath.js
+++ b/vendor/assets/javascripts/ckeditor/basepath.js
@@ -1,1 +1,0 @@
-var CKEDITOR_BASEPATH = '/assets/ckeditor/';

--- a/vendor/assets/javascripts/ckeditor/basepath.js.erb
+++ b/vendor/assets/javascripts/ckeditor/basepath.js.erb
@@ -1,0 +1,2 @@
+var CKEDITOR_BASEPATH = '<%= javascript_path "ckeditor" %>/';
+


### PR DESCRIPTION
I found that if I set a custom basepath for my assets using config.assets.prefix, the CKEDITOR basepath wasn't set right.  This simple patch fixes it.
