### PR TITLE
Update to work in Rails 4 non-fingerprinted environment.

### DIFF
--- a/lib/ckeditor-rails/engine.rb
+++ b/lib/ckeditor-rails/engine.rb
@@ -9,6 +9,10 @@ module Ckeditor
         ckeditor/*.html
         ckeditor/*.md
       )
+
+      rake_tasks do
+        load "ckeditor-rails/tasks.rake"
+      end
     end
   end
 end

--- a/lib/ckeditor-rails/tasks.rake
+++ b/lib/ckeditor-rails/tasks.rake
@@ -1,0 +1,11 @@
+require 'fileutils'
+
+desc "Create nondigest versions of all ckeditor digest assets"
+task "assets:precompile" do
+  fingerprint = /\-[0-9a-f]{32}\./
+  for file in Dir["public/assets/ckeditor/**/*"]
+    next unless file =~ fingerprint
+    nondigest = file.sub fingerprint, '.'
+    FileUtils.cp file, nondigest, verbose: true
+  end
+end


### PR DESCRIPTION
We do this by cheating. Instead of do some crazy mojo to get ckeditor talking
to the fingerprinted versions of the assets we simply create non-fingerprinted
versions like it used to work in Rails 3.

Since this is not what a developer might expect happen we limit our cheat
to only assets produced by ckeditor.

Our task that does this is named assets:precompile. This way our functionality
is appended to the standard funtionality. This will allow it to work in
environments like Heroku where the name of the task that is run to generate
the assets cannot be changed.

The end result is that everything should work out-of-the-box, not affect
anything bug ckeditor and requires minimal changes to this gem.

This fixes issue #18.
