### PR TITLE
Copy fingerprinted assets only if more recent than non-fingerprinted versions

### DIFF
--- a/lib/ckeditor-rails/tasks.rake
+++ b/lib/ckeditor-rails/tasks.rake
@@ -6,6 +6,8 @@ task "assets:precompile" do
   for file in Dir["public/assets/ckeditor/**/*"]
     next unless file =~ fingerprint
     nondigest = file.sub fingerprint, '.'
-    FileUtils.cp file, nondigest, verbose: true
+    if !File.exist?(nondigest) or File.mtime(file) > File.mtime(nondigest)
+      FileUtils.cp file, nondigest, verbose: true
+    end
   end
 end


### PR DESCRIPTION
Fixes non-deterministic behaviour when there are multiple copies of the precompiled assets, as discussed in [pull request 21](https://github.com/tsechingho/ckeditor-rails/pull/21).
