### PR TITLE
Move engine config into initializer

### DIFF
--- a/lib/ckeditor-rails/engine.rb
+++ b/lib/ckeditor-rails/engine.rb
@@ -1,14 +1,16 @@
 module Ckeditor
   module Rails
     class Engine < ::Rails::Engine
-      config.assets.precompile += %W(
-        ckeditor/*.js
-        ckeditor/*.css
-        ckeditor/*.png
-        ckeditor/*.gif
-        ckeditor/*.html
-        ckeditor/*.md
-      )
+      initializer "ckeditor_rails.assets_precompile", :group => :all do |app|
+        app.config.assets.precompile += %W(
+          ckeditor/*.js
+          ckeditor/*.css
+          ckeditor/*.png
+          ckeditor/*.gif
+          ckeditor/*.html
+          ckeditor/*.md
+        )
+      end
 
       rake_tasks do
         load "ckeditor-rails/tasks.rake"


### PR DESCRIPTION
Got error, while `require 'ckedior_rails'` through nested rails engine:

```
/opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/railtie/configuration.rb:95:in 
    `method_missing': undefined method `assets' for #<Rails::Engine::Configuration:0xb9d2b144> (NoMethodError)
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor-rails/engine.rb:4:in `<class:Engine>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor-rails/engine.rb:3:in `<module:Rails>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor-rails/engine.rb:2:in `<module:Ckeditor>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor-rails/engine.rb:1:in `<top (required)>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor-rails.rb:7:in `require'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor-rails.rb:7:in `<module:Rails>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor-rails.rb:4:in `<module:Ckeditor>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor-rails.rb:3:in `<top (required)>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor_rails.rb:1:in `require'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/ckeditor_rails-4.3.4/lib/ckeditor_rails.rb:1:in `<top (required)>'
from /vagrant/modules/common/lib/common/engine.rb:1:in `require'
from /vagrant/modules/common/lib/common/engine.rb:1:in `<top (required)>'
from /vagrant/modules/common/lib/common.rb:1:in `require'
from /vagrant/modules/common/lib/common.rb:1:in `<top (required)>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.0/lib/bundler/runtime.rb:76:in `require'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.0/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.0/lib/bundler/runtime.rb:72:in `each'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.0/lib/bundler/runtime.rb:72:in `block in require'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.0/lib/bundler/runtime.rb:61:in `each'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.0/lib/bundler/runtime.rb:61:in `require'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/bundler-1.5.0/lib/bundler.rb:131:in `require'
from /vagrant/config/application.rb:16:in `<top (required)>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/commands.rb:74:in `require'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/commands.rb:74:in `block in <top (required)>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/commands.rb:71:in `tap'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/commands.rb:71:in `<top (required)>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/app_rails_loader.rb:43:in `require'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/app_rails_loader.rb:43:in `block in exec_app_rails'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/app_rails_loader.rb:32:in `loop'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/app_rails_loader.rb:32:in `exec_app_rails'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/lib/rails/cli.rb:6:in `<top (required)>'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/bin/rails:9:in `require'
from /opt/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/railties-4.0.2/bin/rails:9:in `<top (required)>'
from /opt/rbenv/versions/2.0.0-p353/bin/rails:23:in `load'
from /opt/rbenv/versions/2.0.0-p353/bin/rails:23:in `<main>'

```
