### PR TITLE
Sprockets 3.x compatibility

### DIFF
--- a/lib/ckeditor-rails/tasks.rake
+++ b/lib/ckeditor-rails/tasks.rake
@@ -2,7 +2,7 @@ require 'fileutils'
 
 desc "Create nondigest versions of all ckeditor digest assets"
 task "assets:precompile" do
-  fingerprint = /\-[0-9a-f]{32}\./
+  fingerprint = /\-([0-9a-f]{32}|[0-9a-f]{64})\./
   for file in Dir["public/assets/ckeditor/**/*"]
     next unless file =~ fingerprint
     nondigest = file.sub fingerprint, '.'


### PR DESCRIPTION
Since Rails does not lock Sprockets version, it easy get updated to 3.x
version which happen to use Digest::SHA256 (which is 64 characters).
Additional regexp added against 64 character version.