### PR TITLE
Take custom prefix into account when copying non-digest assets

### DIFF
--- a/lib/ckeditor-rails/tasks.rake
+++ b/lib/ckeditor-rails/tasks.rake
@@ -3,7 +3,7 @@ require 'fileutils'
 desc "Create nondigest versions of all ckeditor digest assets"
 task "assets:precompile" do
   fingerprint = /\-([0-9a-f]{32}|[0-9a-f]{64})\./
-  for file in Dir["public/assets/ckeditor/**/*"]
+  for file in Dir["#{File.join('public', Rails.configuration.assets.prefix)}/ckeditor/**/*"]
     next unless file =~ fingerprint
     nondigest = file.sub fingerprint, '.'
     if !File.exist?(nondigest) or File.mtime(file) > File.mtime(nondigest)


### PR DESCRIPTION
The rake task which copies non-digest assets has a hardcoded asset path, so when a custom prefix is used, non-digest assets aren't created.