### PR TITLE
Update basepath.js.erb

### DIFF
--- a/lib/assets/javascripts/ckeditor/basepath.js.erb
+++ b/lib/assets/javascripts/ckeditor/basepath.js.erb
@@ -1,6 +1,6 @@
 <%
-  base_path = Rails.application.config.assets.prefix + '/ckeditor/'
-  base_path = Rails.application.config.action_controller.relative_url_root + base_path if Rails.application.config.action_controller.relative_url_root
+  base_path = File.join(Rails.application.config.assets.prefix, 'ckeditor/')
+  base_path = File.join(Rails.application.config.action_controller.relative_url_root, base_path) if Rails.application.config.action_controller.relative_url_root
 %>
 
 var CKEDITOR_BASEPATH = "<%= base_path %>";


### PR DESCRIPTION
Use File.join instead of simply concatenating strings. This prevents any double-slashes, which can sometimes be interpreted by the browser as a local file when it occurs at the beginning. 