### PR TITLE
 support for  rails8

### DIFF
--- a/lib/ckeditor-rails.rb
+++ b/lib/ckeditor-rails.rb
@@ -85,7 +85,7 @@ end
 require 'ckeditor-rails/asset'
 
 case ::Rails.version.to_s
-when /^[4567]/
+when /^[45678]/
   require 'ckeditor-rails/engine'
 when /^3\.[12]/
   require 'ckeditor-rails/engine3'


### PR DESCRIPTION
Update the list of supported rails versions in lib/ckeditor-rails.rb to include  rails 8.  No other change.

case ::Rails.version.to_s
when /^[45678]/
  require 'ckeditor-rails/engine'
